### PR TITLE
Better manage server deletion

### DIFF
--- a/tasks/create_server.yml
+++ b/tasks/create_server.yml
@@ -1,13 +1,19 @@
 ---
 - include: generate_keypair.yml
-  when: generate_keypair|bool
+  when: 
+    - generate_keypair|bool
+    - "item_server.state|default(omit) != 'absent'"
+
+- name: "Check server options"
+  assert:
+    that: "item_server.state|default(omit) == 'absent' or item_server.image is defined or item_server.boot_volume is defined"
 
 - name: "Processing server {{ item_server.name }} for {{ item_cloud.oscc_cloud|default(item_cloud.name) }} {{ item_cloud.region_name|default('') }}"
   os_server:
     cloud: "{{ item_cloud.oscc_cloud|default(item_cloud.name) }}"
     state: "{{ item_server.state|default(omit) }}"
     name: "{{ item_server.name.partition('.')[0] }}{{ '' if item_server.node_count is not defined else item }}{{ item_server.name.partition('.')[1] + item_server.name.partition('.')[2] }}"
-    image: "{{ item_server.image }}"
+    image: "{{ item_server.image|default(omit) }}"
     auto_ip: "{{ item_server.auto_ip|default(omit) }}"
     boot_from_volume: "{{ item_server.boot_from_volume|default(omit) }}"
     boot_volume: "{{ item_server.boot_volume|default(omit) }}"
@@ -35,3 +41,4 @@
 
 - add_host: name={{ item.server.name }} groups=cl_servers_just_created ansible_ssh_host={{ item.server.public_v4 }}
   with_items: "{{ os_server_result.results|default([]) }}"
+  when: "item_server.state|default(omit) != 'absent'"


### PR DESCRIPTION
* do not create keypair when deleting server
* allow to omit image arguùent if boot-volume-image is defined
* allow to omit all arguments except name and state if deleting